### PR TITLE
Register change (#16)

### DIFF
--- a/AzureTablesLifecycleManager/Lib/Extensions/FunctionsBuilderExtensions.cs
+++ b/AzureTablesLifecycleManager/Lib/Extensions/FunctionsBuilderExtensions.cs
@@ -4,17 +4,19 @@ using AzureTablesLifecycleManager.Lib.Services;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace AzureTablesLifecycleManager.Lib.Extensions
 {
-	public static class FunctionsBuilderExtensions
-	{
-		public static void RegisterAzureTablesLifecycleManagement(this IFunctionsHostBuilder builder)
-		{
-			builder.Services.AddSingleton(p => new TableServiceClient(p.GetService<IConfiguration>()["AzureWebJobsStorage"]));
-			builder.Services.AddSingleton<ITableRepository, TableRepository>();
-			builder.Services.AddSingleton<ITableManager, TableManager>();
-			builder.Services.AddSingleton<IQueryBuilder, QueryBuilder>();
-		}
-	}
+    public static class FunctionsBuilderExtensions
+    {
+        [Obsolete("RegisterAzureTablesLifecycleManagement method is deprecated. Use IServiceCollection extension method AddAzureTablesLifecycleManagement instead.")]
+        public static void RegisterAzureTablesLifecycleManagement(this IFunctionsHostBuilder builder)
+        {
+            builder.Services.AddSingleton(p => new TableServiceClient(p.GetService<IConfiguration>()["AzureWebJobsStorage"]));
+            builder.Services.AddSingleton<ITableRepository, TableRepository>();
+            builder.Services.AddSingleton<ITableManager, TableManager>();
+            builder.Services.AddSingleton<IQueryBuilder, QueryBuilder>();
+        }
+    }
 }

--- a/AzureTablesLifecycleManager/Lib/Extensions/ServiceCollectionExtensions.cs
+++ b/AzureTablesLifecycleManager/Lib/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+﻿using Azure.Data.Tables;
+using AzureTablesLifecycleManager.AzureDAL.APIGateway;
+using AzureTablesLifecycleManager.Lib.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace AzureTablesLifecycleManager.Lib.Extensions
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddAzureTablesLifecycleManagement(this IServiceCollection services)
+        {
+            services.AddSingleton(p => new TableServiceClient(Environment.GetEnvironmentVariable("AzureWebJobsStorage")));
+            services.AddSingleton<ITableRepository, TableRepository>();
+            services.AddSingleton<ITableManager, TableManager>();
+            services.AddSingleton<IQueryBuilder, QueryBuilder>();
+        }
+
+        public static void AddAzureTablesLifecycleManagement(this IServiceCollection services, string connectionString)
+        {
+            services.AddSingleton(p => new TableServiceClient(connectionString));
+            services.AddSingleton<ITableRepository, TableRepository>();
+            services.AddSingleton<ITableManager, TableManager>();
+            services.AddSingleton<IQueryBuilder, QueryBuilder>();
+        }
+    }
+}


### PR DESCRIPTION
Changed the way the package is registered: using `IServiceCollection` extension and using `Environment` instead of `IConfiguration` to grab the storage account connection string. Old register method marked as `Obsolete`.